### PR TITLE
Fix git alias bug

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -10,7 +10,7 @@
     cam = commit --amend -m
     co = checkout
     cob = checkout -b
-    col = ! git checkout `git branch --sort=-authordate | fzf | sed 's/^*//'`
+    col = ! git checkout $(git branch --sort=-authordate | fzf | sed 's/^..//')
     cp = cherry-pick
     d = diff
     dc = diff --cached

--- a/.config/git/config
+++ b/.config/git/config
@@ -10,7 +10,7 @@
     cam = commit --amend -m
     co = checkout
     cob = checkout -b
-    col = ! git checkout $(git branch --sort=-authordate | fzf | sed 's/^..//')
+    col = ! git checkout $(git for-each-ref --sort=-authordate --format='%(refname:short)' refs/heads/ | fzf)
     cp = cherry-pick
     d = diff
     dc = diff --cached


### PR DESCRIPTION
## Summary
- fix alias for checking out recently authored branches

## Testing
- `shellcheck .config/zsh/zshrc` *(fails: Parameter expansions can't start with (.) etc.)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843b764a7bc832bb19ea63431d2b823