### PR TITLE
Add config parsing tests with CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install pytest toml
+      - name: Run tests
+        run: pytest -v

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -14,5 +14,5 @@ def test_load_configs():
         json.load(f)
 
     starship_path = repo_root / ".config" / "starship.toml"
-    with starship_path.open('r', encoding='utf-8') as f:
+    with starship_path.open('rb') as f:
         tomllib.load(f)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -14,5 +14,5 @@ def test_load_configs():
         json.load(f)
 
     starship_path = repo_root / ".config" / "starship.toml"
-    with starship_path.open('rb') as f:
+    with starship_path.open('r', encoding='utf-8') as f:
         tomllib.load(f)

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,0 +1,18 @@
+import json
+import pathlib
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older versions
+    import toml as tomllib
+
+
+def test_load_configs():
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    karabiner_path = repo_root / ".config" / "karabiner" / "karabiner.json"
+    with karabiner_path.open('r', encoding='utf-8') as f:
+        json.load(f)
+
+    starship_path = repo_root / ".config" / "starship.toml"
+    with starship_path.open('rb') as f:
+        tomllib.load(f)


### PR DESCRIPTION
## Summary
- add a simple pytest that loads `.config/karabiner/karabiner.json` and `.config/starship.toml`
- configure GitHub Actions workflow to run tests

## Testing
- `pytest -v`

------
https://chatgpt.com/codex/tasks/task_e_6843c1a65f10832badb61d0abc18efbf