### PR TITLE
Fix VSCode zshrc crash

### DIFF
--- a/.config/zsh/zshrc
+++ b/.config/zsh/zshrc
@@ -1,5 +1,8 @@
 # directory fullpath of this file
-FILE_DIR="$(cd "$(dirname "${(%):-%N}")" && pwd)"
+# Use zsh's built in path expansion to resolve the directory that
+# contains this file. This avoids relying on `cd` and `dirname`, which
+# can misbehave in some environments such as VSCode.
+FILE_DIR=${${(%):-%N}:A:h}
 
 alias ls="ls -hlp --color"
 alias lsa="ls -a"

--- a/.config/zsh/zshrc
+++ b/.config/zsh/zshrc
@@ -2,7 +2,7 @@
 # Use zsh's built in path expansion to resolve the directory that
 # contains this file. This avoids relying on `cd` and `dirname`, which
 # can misbehave in some environments such as VSCode.
-FILE_DIR=${${(%):-%N}:A:h}
+FILE_DIR="${${(%):-%N}:A:h}"
 
 alias ls="ls -hlp --color"
 alias lsa="ls -a"


### PR DESCRIPTION
## Summary
- use zsh builtin expansion to set `FILE_DIR`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687071cab650832b814b29e92a21a9bb